### PR TITLE
Enabled alternate issuer address

### DIFF
--- a/verifytoken.ashx.cs
+++ b/verifytoken.ashx.cs
@@ -90,7 +90,7 @@ namespace VerifyToken
                         ValidAudience = CLIENT_ID,
 
                         ValidateIssuer = true, // check token came from Google
-                        ValidIssuer = "accounts.google.com",
+                        ValidIssuers = new List<string> { "accounts.google.com", "https://accounts.google.com" },
 
                         ValidateIssuerSigningKey = true,
                         RequireSignedTokens = true,


### PR DESCRIPTION
The specification allows for two different issuer strings. This fixes the omission of "https://accounts.google.com" as one of them.
